### PR TITLE
feat: allow `Observer`s to modify fit `Status` and terminate minimization

### DIFF
--- a/src/observers.rs
+++ b/src/observers.rs
@@ -25,7 +25,8 @@ use crate::{Observer, Status};
 /// ```
 pub struct DebugObserver;
 impl<T: Scalar, U: Debug> Observer<T, U> for DebugObserver {
-    fn callback(&mut self, step: usize, status: &Status<T>, user_data: &mut U) {
-        println!("{step}, {:?}, {:?}", status, user_data)
+    fn callback(&mut self, step: usize, status: &mut Status<T>, user_data: &mut U) -> bool {
+        println!("{step}, {:?}, {:?}", status, user_data);
+        true
     }
 }


### PR DESCRIPTION
This opens a path for a solution for denehoffman/laddu#5. `Observer`s now return a `bool` where `true` signals that the minimization should proceed. If the `Observer` sees a reason why the minimization should terminate, it can return `false` and also change the `Status` of the minimizer, which is now passed as a mutable reference.