### PR TITLE
Change default tolerances to be a bit more realistic

### DIFF
--- a/src/algorithms/bfgs.rs
+++ b/src/algorithms/bfgs.rs
@@ -121,7 +121,7 @@ where
             h_inv: Default::default(),
             f_previous: T::infinity(),
             terminator_f: BFGSFTerminator {
-                tol_f_abs: T::epsilon(),
+                tol_f_abs: Float::sqrt(T::epsilon()),
             },
             terminator_g: BFGSGTerminator {
                 tol_g_abs: Float::cbrt(T::epsilon()),
@@ -248,7 +248,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use float_cmp::approx_eq;
+    use float_cmp::assert_approx_eq;
 
     use crate::{prelude::*, test_functions::Rosenbrock};
 
@@ -261,22 +261,22 @@ mod tests {
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-5);
         m.minimize(&problem, &[2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-5);
         m.minimize(&problem, &[2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-5);
         m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-5);
         m.minimize(&problem, &[0.0, 0.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-5);
         m.minimize(&problem, &[1.0, 1.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         Ok(())
     }
 }

--- a/src/algorithms/lbfgs.rs
+++ b/src/algorithms/lbfgs.rs
@@ -127,7 +127,7 @@ where
             g: Default::default(),
             f_previous: T::infinity(),
             terminator_f: LBFGSFTerminator {
-                tol_f_abs: T::epsilon(),
+                tol_f_abs: Float::sqrt(T::epsilon()),
             },
             terminator_g: LBFGSGTerminator {
                 tol_g_abs: Float::cbrt(T::epsilon()),
@@ -275,7 +275,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use float_cmp::approx_eq;
+    use float_cmp::assert_approx_eq;
 
     use crate::{prelude::*, test_functions::Rosenbrock};
 
@@ -288,22 +288,22 @@ mod tests {
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-8);
         m.minimize(&problem, &[2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-9);
         m.minimize(&problem, &[0.0, 0.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[1.0, 1.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         Ok(())
     }
 }

--- a/src/algorithms/lbfgsb.rs
+++ b/src/algorithms/lbfgsb.rs
@@ -143,12 +143,12 @@ where
             theta: T::one(),
             f_previous: T::infinity(),
             terminator_f: LBFGSBFTerminator {
-                tol_f_abs: T::epsilon(),
+                tol_f_abs: Float::sqrt(T::epsilon()),
             },
             terminator_g: LBFGSBGTerminator {
                 tol_g_abs: Float::cbrt(T::epsilon()),
             },
-            g_tolerance: convert!(1e-5, T),
+            g_tolerance: Float::cbrt(T::epsilon()),
             line_search: Box::new(StrongWolfeLineSearch::default()),
             m: 10,
             y_store: VecDeque::default(),
@@ -505,7 +505,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use float_cmp::approx_eq;
+    use float_cmp::assert_approx_eq;
 
     use crate::{prelude::*, test_functions::Rosenbrock};
 
@@ -518,22 +518,22 @@ mod tests {
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-6);
         m.minimize(&problem, &[2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[0.0, 0.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         m.minimize(&problem, &[1.0, 1.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         Ok(())
     }
 }

--- a/src/algorithms/nelder_mead.rs
+++ b/src/algorithms/nelder_mead.rs
@@ -594,10 +594,10 @@ where
             construction_method: SimplexConstructionMethod::default(),
             expansion_method: SimplexExpansionMethod::default(),
             terminator_f: NelderMeadFTerminator::StdDev {
-                tol_f_abs: T::epsilon(),
+                tol_f_abs: T::epsilon().powf(convert!(0.25, T)),
             },
             terminator_x: NelderMeadXTerminator::Singer {
-                tol_x_rel: T::epsilon(),
+                tol_x_rel: T::epsilon().powf(convert!(0.25, T)),
             },
             compute_parameter_errors: true,
         }
@@ -883,7 +883,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use float_cmp::approx_eq;
+    use float_cmp::assert_approx_eq;
 
     use crate::{prelude::*, test_functions::Rosenbrock};
 
@@ -896,22 +896,22 @@ mod tests {
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-3);
         m.minimize(&problem, &[2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[0.0, 0.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[1.0, 1.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         Ok(())
     }
 
@@ -922,22 +922,22 @@ mod tests {
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-3);
         m.minimize(&problem, &[2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[0.0, 0.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-4);
         m.minimize(&problem, &[1.0, 1.0], &mut ())?;
         assert!(m.status.converged);
-        assert!(approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10));
+        assert_approx_eq!(f64, m.status.fx, 0.0, epsilon = 1e-10);
         Ok(())
     }
 }


### PR DESCRIPTION
The default epsilon values for basically all the methods were a bit too precise. While they work fine for the Rosenbrock demos, most real-world applications don't start with that level of precision (scipy uses 1e-4 for both tolerances on their Nelder-Mead and esp * 1e7 for their 64-bit float tolerance for L-BFGS-B, for example). I've tried to scale these and use values that can work with either 64- or 32-bit floats and approximate those used by the 64-bit only existing libraries (scipy and the FORTRAN implementation of L-BFGS-B). As a result, tests needed to be updated (in precision only) and benchmarks will probably run faster simply because it will take fewer steps to converge.