### PR TITLE
Remove Clone requirement on generics for algorithms that store a `LineSearch`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use ganesh::algorithms::NelderMead;
 fn main() -> Result<(), Infallible> {
     let problem = Rosenbrock { n: 2 };
     let nm = NelderMead::default();
-    let mut m = Minimizer::new(&nm, 2);
+    let mut m = Minimizer::new(Box::new(nm), 2);
     let x0 = &[2.0, 2.0];
     m.minimize(&problem, x0, &mut ())?;
     println!("{}", m.status);

--- a/benches/bfgs_benchmark.rs
+++ b/benches/bfgs_benchmark.rs
@@ -9,7 +9,7 @@ fn bfgs_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("Rosenbrock", n), &n, |b, ndim| {
             let problem = Rosenbrock { n: *ndim };
             let nm = BFGS::default();
-            let mut m = Minimizer::new(&nm, *ndim).with_max_steps(10_000_000);
+            let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
                 m.minimize(&problem, &x0, &mut ()).unwrap();

--- a/benches/lbfgs_benchmark.rs
+++ b/benches/lbfgs_benchmark.rs
@@ -9,7 +9,7 @@ fn lbfgs_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("Rosenbrock", n), &n, |b, ndim| {
             let problem = Rosenbrock { n: *ndim };
             let nm = LBFGS::default();
-            let mut m = Minimizer::new(&nm, *ndim).with_max_steps(10_000_000);
+            let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
                 m.minimize(&problem, &x0, &mut ()).unwrap();

--- a/benches/lbfgsb_benchmark.rs
+++ b/benches/lbfgsb_benchmark.rs
@@ -9,7 +9,7 @@ fn lbfgsb_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("Rosenbrock", n), &n, |b, ndim| {
             let problem = Rosenbrock { n: *ndim };
             let nm = LBFGSB::default();
-            let mut m = Minimizer::new(&nm, *ndim).with_max_steps(10_000_000);
+            let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
                 m.minimize(&problem, &x0, &mut ()).unwrap();

--- a/benches/nelder_mead_benchmark.rs
+++ b/benches/nelder_mead_benchmark.rs
@@ -9,7 +9,7 @@ fn nelder_mead_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("Rosenbrock", n), &n, |b, ndim| {
             let problem = Rosenbrock { n: *ndim };
             let nm = NelderMead::default();
-            let mut m = Minimizer::new(&nm, *ndim).with_max_steps(10_000_000);
+            let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
                 m.minimize(&problem, &x0, &mut ()).unwrap();
@@ -22,7 +22,7 @@ fn nelder_mead_benchmark(c: &mut Criterion) {
             |b, ndim| {
                 let problem = Rosenbrock { n: *ndim };
                 let nm = NelderMead::default().with_adaptive(n);
-                let mut m = Minimizer::new(&nm, *ndim).with_max_steps(10_000_000);
+                let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
                 let x0 = vec![5.0; *ndim];
                 b.iter(|| {
                     m.minimize(&problem, &x0, &mut ()).unwrap();

--- a/examples/multivariate_normal_ess/main.rs
+++ b/examples/multivariate_normal_ess/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build();
 
     // Create a new Sampler
-    let mut s = Sampler::new(&a, x0).with_observer(aco.clone());
+    let mut s = Sampler::new(Box::new(a), x0).with_observer(aco.clone());
 
     // Run a maximum of 1000 steps of the MCMC algorithm
     s.sample(&problem, &mut cov_inv, 1000)?;

--- a/src/algorithms/bfgs.rs
+++ b/src/algorithms/bfgs.rs
@@ -133,11 +133,7 @@ impl<U, E> BFGS<U, E> {
     }
 }
 
-impl<U, E> Algorithm<U, E> for BFGS<U, E>
-where
-    U: Clone,
-    E: Clone,
-{
+impl<U, E> Algorithm<U, E> for BFGS<U, E> {
     fn initialize(
         &mut self,
         func: &dyn Function<U, E>,
@@ -240,7 +236,7 @@ mod tests {
     #[test]
     fn test_bfgs() -> Result<(), Infallible> {
         let algo = BFGS::default();
-        let mut m = Minimizer::new(&algo, 2).with_max_steps(10000);
+        let mut m = Minimizer::new(Box::new(algo), 2).with_max_steps(10000);
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);

--- a/src/algorithms/lbfgs.rs
+++ b/src/algorithms/lbfgs.rs
@@ -154,11 +154,7 @@ impl<U, E> LBFGS<U, E> {
     }
 }
 
-impl<U, E> Algorithm<U, E> for LBFGS<U, E>
-where
-    U: Clone,
-    E: Clone,
-{
+impl<U, E> Algorithm<U, E> for LBFGS<U, E> {
     fn initialize(
         &mut self,
         func: &dyn Function<U, E>,
@@ -267,7 +263,7 @@ mod tests {
     #[test]
     fn test_lbfgs() -> Result<(), Infallible> {
         let algo = LBFGS::default();
-        let mut m = Minimizer::new(&algo, 2);
+        let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);

--- a/src/algorithms/lbfgsb.rs
+++ b/src/algorithms/lbfgsb.rs
@@ -349,11 +349,7 @@ impl<U, E> LBFGSB<U, E> {
     }
 }
 
-impl<U, E> Algorithm<U, E> for LBFGSB<U, E>
-where
-    U: Clone,
-    E: Clone,
-{
+impl<U, E> Algorithm<U, E> for LBFGSB<U, E> {
     fn initialize(
         &mut self,
         func: &dyn Function<U, E>,
@@ -495,7 +491,7 @@ mod tests {
     #[test]
     fn test_lbfgsb() -> Result<(), Infallible> {
         let algo = LBFGSB::default();
-        let mut m = Minimizer::new(&algo, 2);
+        let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
@@ -521,7 +517,8 @@ mod tests {
     #[test]
     fn test_bounded_lbfgsb() -> Result<(), Infallible> {
         let algo = LBFGSB::default();
-        let mut m = Minimizer::new(&algo, 2).with_bounds(Some(vec![(-4.0, 4.0), (-4.0, 4.0)]));
+        let mut m =
+            Minimizer::new(Box::new(algo), 2).with_bounds(Some(vec![(-4.0, 4.0), (-4.0, 4.0)]));
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);

--- a/src/algorithms/nelder_mead.rs
+++ b/src/algorithms/nelder_mead.rs
@@ -731,7 +731,7 @@ mod tests {
     #[test]
     fn test_nelder_mead() -> Result<(), Infallible> {
         let algo = NelderMead::default();
-        let mut m = Minimizer::new(&algo, 2);
+        let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
@@ -757,7 +757,8 @@ mod tests {
     #[test]
     fn test_bounded_nelder_mead() -> Result<(), Infallible> {
         let algo = NelderMead::default();
-        let mut m = Minimizer::new(&algo, 2).with_bounds(Some(vec![(-4.0, 4.0), (-4.0, 4.0)]));
+        let mut m =
+            Minimizer::new(Box::new(algo), 2).with_bounds(Some(vec![(-4.0, 4.0), (-4.0, 4.0)]));
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);
@@ -783,7 +784,7 @@ mod tests {
     #[test]
     fn test_adaptive_nelder_mead() -> Result<(), Infallible> {
         let algo = NelderMead::default().with_adaptive(2);
-        let mut m = Minimizer::new(&algo, 2);
+        let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
         m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
         assert!(m.status.converged);

--- a/src/observers.rs
+++ b/src/observers.rs
@@ -22,7 +22,7 @@ use crate::{
 /// let problem = Rosenbrock { n: 2 };
 /// let nm = NelderMead::default();
 /// let obs = DebugObserver::build();
-/// let mut m = Minimizer::new(&nm, 2).with_observer(obs);
+/// let mut m = Minimizer::new(Box::new(nm), 2).with_observer(obs);
 /// m.minimize(&problem, &[2.3, 3.4], &mut ()).unwrap();
 /// // ^ This will print debug messages for each step
 /// assert!(m.status.converged);
@@ -60,7 +60,7 @@ impl<U: Debug> Observer<U> for DebugObserver {
 /// let x0 = (0..5).map(|_| DVector::from_fn(2, |_, _| rng.normal(1.0, 4.0))).collect();
 /// let ess = ESS::new([ESSMove::gaussian(0.1), ESSMove::differential(0.9)], rng);
 /// let obs = DebugMCMCObserver::build();
-/// let mut sampler = Sampler::new(&ess, x0).with_observer(obs);
+/// let mut sampler = Sampler::new(Box::new(ess), x0).with_observer(obs);
 /// sampler.sample(&problem, &mut (), 10).unwrap();
 /// // ^ This will print debug messages for each step
 /// assert!(sampler.ensemble.dimension() == (5, 10, 2));
@@ -103,7 +103,7 @@ impl<U: Debug> MCMCObserver<U> for DebugMCMCObserver {
 /// let x0 = (0..5).map(|_| DVector::from_fn(2, |_, _| rng.normal(1.0, 4.0))).collect();
 /// let ess = ESS::new([ESSMove::gaussian(0.1), ESSMove::differential(0.9)], rng);
 /// let obs = AutocorrelationObserver::default().with_n_check(20).build();
-/// let mut sampler = Sampler::new(&ess, x0).with_observer(obs);
+/// let mut sampler = Sampler::new(Box::new(ess), x0).with_observer(obs);
 /// sampler.sample(&problem, &mut (), 100).unwrap();
 /// // ^ This will print autocorrelation messages for every 20 steps
 /// assert!(sampler.ensemble.dimension() == (5, 100, 2));


### PR DESCRIPTION
Due to the way that algorithms like those in the BFGS family are implemented, creating a new `Minimizer` over a `Function<U, E>` required `U` and `E` to have a `Clone` trait bound. Since most `Error` implementers don't do this, and since it's a hassle to require all user-data-like arguments to be `Clone`, I have made *boxed* `dyn Algorithm`s the default way to create a new `Minimizer`. This is a bit ugly, but I can't think of a better way without a ton of refactoring.