### PR TITLE
Use abort signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,6 @@ dependencies = [
  "dyn-clone",
  "fastrand",
  "fastrand-contrib",
- "lazy_static",
  "logsumexp",
  "nalgebra",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ exclude = ["src/main.rs", "*.png", "*.svg", "*.gif", "*.pkl"]
 [dependencies]
 nalgebra = { version = "0.33.0", features = ["serde-serialize"] }
 ctrlc = "3.4.5"
-lazy_static = "1.5.0"
 dyn-clone = "1.0.17"
 serde = { version = "1.0.214", features = ["derive", "rc"] }
 serde-pickle = "1.2.0"

--- a/benches/lbfgsb_benchmark.rs
+++ b/benches/lbfgsb_benchmark.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ganesh::abort_signal::CtrlCAbortSignal;
 use ganesh::algorithms::LBFGSB;
 use ganesh::test_functions::rosenbrock::Rosenbrock;
+use ganesh::traits::AbortSignal;
 use ganesh::Minimizer;
 
 fn lbfgsb_benchmark(c: &mut Criterion) {
@@ -12,7 +14,8 @@ fn lbfgsb_benchmark(c: &mut Criterion) {
             let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
-                m.minimize(&problem, &x0, &mut ()).unwrap();
+                m.minimize(&problem, &x0, &mut (), CtrlCAbortSignal::new().boxed())
+                    .unwrap();
                 black_box(&m.status);
             });
         });

--- a/benches/nelder_mead_benchmark.rs
+++ b/benches/nelder_mead_benchmark.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ganesh::abort_signal::CtrlCAbortSignal;
 use ganesh::algorithms::NelderMead;
 use ganesh::test_functions::rosenbrock::Rosenbrock;
+use ganesh::traits::AbortSignal;
 use ganesh::Minimizer;
 
 fn nelder_mead_benchmark(c: &mut Criterion) {
@@ -12,7 +14,8 @@ fn nelder_mead_benchmark(c: &mut Criterion) {
             let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
             let x0 = vec![5.0; *ndim];
             b.iter(|| {
-                m.minimize(&problem, &x0, &mut ()).unwrap();
+                m.minimize(&problem, &x0, &mut (), CtrlCAbortSignal::new().boxed())
+                    .unwrap();
                 black_box(&m.status);
             });
         });
@@ -25,7 +28,8 @@ fn nelder_mead_benchmark(c: &mut Criterion) {
                 let mut m = Minimizer::new(Box::new(nm), *ndim).with_max_steps(10_000_000);
                 let x0 = vec![5.0; *ndim];
                 b.iter(|| {
-                    m.minimize(&problem, &x0, &mut ()).unwrap();
+                    m.minimize(&problem, &x0, &mut (), CtrlCAbortSignal::new().boxed())
+                        .unwrap();
                     black_box(&m.status);
                 });
             },

--- a/examples/multimodal_ess/main.rs
+++ b/examples/multimodal_ess/main.rs
@@ -4,8 +4,10 @@ use std::io::BufWriter;
 use std::path::Path;
 
 use fastrand::Rng;
+use ganesh::abort_signal::CtrlCAbortSignal;
 use ganesh::observers::AutocorrelationObserver;
 use ganesh::samplers::ess::{ESSMove, ESS};
+use ganesh::traits::AbortSignal;
 use ganesh::Sampler;
 use ganesh::{Float, Function, SampleFloat};
 use nalgebra::DVector;
@@ -56,7 +58,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut s = Sampler::new(Box::new(a), x0).with_observer(aco.clone());
 
     // Run a maximum of 4000 steps of the MCMC algorithm
-    s.sample(&problem, &mut (), 4000)?;
+    s.sample(&problem, &mut (), 4000, CtrlCAbortSignal::new().boxed())?;
 
     // Get the resulting samples (no burn-in)
     let chains = s.get_chains(None, None);

--- a/examples/multivariate_normal_ess/main.rs
+++ b/examples/multivariate_normal_ess/main.rs
@@ -4,8 +4,10 @@ use std::io::BufWriter;
 use std::path::Path;
 
 use fastrand::Rng;
+use ganesh::abort_signal::CtrlCAbortSignal;
 use ganesh::observers::AutocorrelationObserver;
 use ganesh::samplers::ess::{ESSMove, ESS};
+use ganesh::traits::AbortSignal;
 use ganesh::Sampler;
 use ganesh::{Float, Function, SampleFloat};
 use nalgebra::{DMatrix, DVector};
@@ -54,7 +56,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut s = Sampler::new(Box::new(a), x0).with_observer(aco.clone());
 
     // Run a maximum of 1000 steps of the MCMC algorithm
-    s.sample(&problem, &mut cov_inv, 1000)?;
+    s.sample(
+        &problem,
+        &mut cov_inv,
+        1000,
+        CtrlCAbortSignal::new().boxed(),
+    )?;
 
     // Get the resulting samples (no burn-in)
     let chains = s.get_chains(None, None);

--- a/examples/pso/main.rs
+++ b/examples/pso/main.rs
@@ -4,8 +4,10 @@ use std::io::BufWriter;
 use std::path::Path;
 
 use fastrand::Rng;
+use ganesh::abort_signal::CtrlCAbortSignal;
 use ganesh::observers::TrackingSwarmObserver;
 use ganesh::swarms::{SwarmPositionInitializer, PSO};
+use ganesh::traits::AbortSignal;
 use ganesh::{Float, Function, Swarm};
 use ganesh::{SwarmMinimizer, PI};
 use std::error::Error;
@@ -45,7 +47,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_max_steps(200);
 
     // Run the particle swarm optimizer
-    s.minimize(&problem, &mut ())?;
+    s.minimize(&problem, &mut (), CtrlCAbortSignal::new().boxed())?;
 
     println!("{}", s.swarm);
 

--- a/src/abort_signal.rs
+++ b/src/abort_signal.rs
@@ -1,0 +1,110 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::Once;
+
+/// A trait for abort signals.
+/// This trait is used in minimizers to check if the user has requested to abort the calculation.
+pub trait AbortSignal {
+    /// Return `true` if the user has requested to abort the calculation.
+    fn is_aborted(&self) -> bool;
+    /// Abort the calculation. Make `is_aborted()` return `true`.
+    fn abort(&self);
+    /// Reset the abort signal. Make `is_aborted()` return `false`.
+    fn reset(&self);
+    /// Return a boxed version of the signal.
+    fn boxed(self) -> Box<Self>
+    where
+        Self: Sized,
+    {
+        Box::new(self)
+    }
+}
+
+static INIT: Once = Once::new();
+static CTRL_C_PRESSED: AtomicBool = AtomicBool::new(false);
+
+/// A signal that is triggered when the user presses `Ctrl-C`.
+/// <div class="warning">This signal takes over the `Ctrl-C` handler for the whole process and can interfere with
+/// other libraries that use `Ctrl-C` (e.g. `tokio`).</div>
+pub struct CtrlCAbortSignal {}
+impl CtrlCAbortSignal {
+    /// Create a new `CtrlCAbortSignal` and register a ctrl-c handler.
+    pub fn new() -> Self {
+        let signal = Self {};
+        signal.init_handler();
+        signal
+    }
+
+    fn init_handler(&self) {
+        INIT.call_once(|| {
+            #[allow(clippy::expect_used)]
+            ctrlc::set_handler(move || {
+                println!("Ctrl-C pressed");
+                CTRL_C_PRESSED.store(true, Ordering::SeqCst);
+            })
+            .expect("Error setting Ctrl-C handler");
+        });
+    }
+}
+
+impl AbortSignal for CtrlCAbortSignal {
+    fn is_aborted(&self) -> bool {
+        CTRL_C_PRESSED.load(Ordering::SeqCst)
+    }
+
+    fn abort(&self) {
+        CTRL_C_PRESSED.store(true, Ordering::SeqCst)
+    }
+
+    fn reset(&self) {
+        CTRL_C_PRESSED.store(false, Ordering::SeqCst);
+    }
+}
+
+/// A signal that is never triggered.
+pub struct NopAbortSignal;
+
+impl NopAbortSignal {
+    /// Create a new `NopAbortSignal`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AbortSignal for NopAbortSignal {
+    fn is_aborted(&self) -> bool {
+        false
+    }
+
+    fn abort(&self) {}
+
+    fn reset(&self) {}
+}
+
+/// A signal that is triggered by setting an atomic boolean.
+pub struct AtomicAbortSignal {
+    abort: AtomicBool,
+}
+
+impl AtomicAbortSignal {
+    /// Create a new `AtomicAbortSignal`.
+    pub fn new() -> Self {
+        Self {
+            abort: AtomicBool::new(false),
+        }
+    }
+}
+
+impl AbortSignal for AtomicAbortSignal {
+    fn is_aborted(&self) -> bool {
+        self.abort.load(Ordering::SeqCst)
+    }
+
+    fn abort(&self) {
+        self.abort.store(true, Ordering::SeqCst);
+    }
+
+    fn reset(&self) {
+        self.abort.store(false, Ordering::SeqCst);
+    }
+}

--- a/src/algorithms/lbfgsb.rs
+++ b/src/algorithms/lbfgsb.rs
@@ -505,7 +505,10 @@ mod tests {
 
     use approx::assert_relative_eq;
 
-    use crate::{test_functions::Rosenbrock, Float, Minimizer};
+    use crate::{
+        abort_signal::CtrlCAbortSignal, test_functions::Rosenbrock, traits::AbortSignal, Float,
+        Minimizer,
+    };
 
     use super::LBFGSB;
 
@@ -514,22 +517,52 @@ mod tests {
         let algo = LBFGSB::default();
         let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
-        m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[0.0, 0.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[0.0, 0.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[1.0, 1.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[1.0, 1.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
         Ok(())
@@ -540,22 +573,52 @@ mod tests {
         let algo = LBFGSB::default();
         let mut m = Minimizer::new(Box::new(algo), 2).with_bounds(vec![(-4.0, 4.0), (-4.0, 4.0)]);
         let problem = Rosenbrock { n: 2 };
-        m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[0.0, 0.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[0.0, 0.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
-        m.minimize(&problem, &[1.0, 1.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[1.0, 1.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
         Ok(())

--- a/src/algorithms/nelder_mead.rs
+++ b/src/algorithms/nelder_mead.rs
@@ -762,7 +762,10 @@ mod tests {
 
     use approx::assert_relative_eq;
 
-    use crate::{test_functions::Rosenbrock, Float, Minimizer};
+    use crate::{
+        abort_signal::CtrlCAbortSignal, test_functions::Rosenbrock, traits::AbortSignal, Float,
+        Minimizer,
+    };
 
     use super::NelderMead;
 
@@ -771,22 +774,52 @@ mod tests {
         let algo = NelderMead::default();
         let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
-        m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(1.0 / 5.0));
-        m.minimize(&problem, &[2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[0.0, 0.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[0.0, 0.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[1.0, 1.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[1.0, 1.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
         Ok(())
@@ -797,22 +830,52 @@ mod tests {
         let algo = NelderMead::default();
         let mut m = Minimizer::new(Box::new(algo), 2).with_bounds(vec![(-4.0, 4.0), (-4.0, 4.0)]);
         let problem = Rosenbrock { n: 2 };
-        m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(1.0 / 5.0));
-        m.minimize(&problem, &[2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(1.0 / 5.0));
-        m.minimize(&problem, &[0.0, 0.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[0.0, 0.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(1.0 / 5.0));
-        m.minimize(&problem, &[1.0, 1.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[1.0, 1.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
         Ok(())
@@ -823,22 +886,52 @@ mod tests {
         let algo = NelderMead::default().with_adaptive(2);
         let mut m = Minimizer::new(Box::new(algo), 2);
         let problem = Rosenbrock { n: 2 };
-        m.minimize(&problem, &[-2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[2.0, 2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, 2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(1.0 / 5.0));
-        m.minimize(&problem, &[2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[-2.0, -2.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[-2.0, -2.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[0.0, 0.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[0.0, 0.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.powf(0.25));
-        m.minimize(&problem, &[1.0, 1.0], &mut ())?;
+        m.minimize(
+            &problem,
+            &[1.0, 1.0],
+            &mut (),
+            CtrlCAbortSignal::new().boxed(),
+        )?;
         assert!(m.status.converged);
         assert_relative_eq!(m.status.fx, 0.0, epsilon = Float::EPSILON.sqrt());
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,17 +190,10 @@
     missing_docs
 )]
 
-use std::{
-    fmt::{Debug, Display},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Once,
-    },
-};
+use std::fmt::{Debug, Display};
 
 use fastrand::Rng;
 use fastrand_contrib::RngExt;
-use lazy_static::lazy_static;
 use nalgebra::{Cholesky, DMatrix, DVector};
 use serde::{Deserialize, Serialize};
 
@@ -221,35 +214,17 @@ pub mod observers;
 /// Module containing standard functions for testing algorithms
 pub mod test_functions;
 
+/// Module containing a trait for aborting algorithms
+pub mod abort_signal;
+
 /// Module containing useful traits
 pub mod traits {
+    pub use crate::abort_signal::AbortSignal;
     pub use crate::algorithms::Algorithm;
     pub use crate::observers::{MCMCObserver, Observer};
     pub use crate::samplers::MCMCAlgorithm;
     pub use crate::swarms::SwarmAlgorithm;
     pub use crate::{Function, SampleFloat};
-}
-
-lazy_static! {
-    pub(crate) static ref CTRL_C_PRESSED: AtomicBool = AtomicBool::new(false);
-}
-
-static INIT: Once = Once::new();
-
-pub(crate) fn init_ctrl_c_handler() {
-    INIT.call_once(|| {
-        #[allow(clippy::expect_used)]
-        ctrlc::set_handler(move || CTRL_C_PRESSED.store(true, Ordering::SeqCst))
-            .expect("Error setting Ctrl-C handler");
-    });
-}
-
-pub(crate) fn reset_ctrl_c_handler() {
-    CTRL_C_PRESSED.store(false, Ordering::SeqCst)
-}
-
-pub(crate) fn is_ctrl_c_pressed() -> bool {
-    CTRL_C_PRESSED.load(Ordering::SeqCst)
 }
 
 /// A floating-point number type (defaults to [`f64`], see `f32` feature).

--- a/src/swarms/pso.rs
+++ b/src/swarms/pso.rs
@@ -22,7 +22,7 @@ use crate::{generate_random_vector, Bound, Float, Function, Swarm};
 /// topology). See [^1] for more information.
 ///
 /// For bounds handling, see [^2]. The only method not given there is the
-/// [`super::BoundaryMethod::Transform`] option, which uses the typical nonlinear bounds transformation
+/// [`BoundaryMethod::Transform`] option, which uses the typical nonlinear bounds transformation
 /// supplied by this crate.
 ///
 ///

--- a/src/swarms/pso.rs
+++ b/src/swarms/pso.rs
@@ -22,7 +22,7 @@ use crate::{generate_random_vector, Bound, Float, Function, Swarm};
 /// topology). See [^1] for more information.
 ///
 /// For bounds handling, see [^2]. The only method not given there is the
-/// [`BoundaryMethod::Transform`] option, which uses the typical nonlinear bounds transformation
+/// [`super::BoundaryMethod::Transform`] option, which uses the typical nonlinear bounds transformation
 /// supplied by this crate.
 ///
 ///


### PR DESCRIPTION
The use of a ctrl-c handler in a library inferes with other libraries or bigger applications.
In order to create a mechanism that allows to opt-in for this behavior, I added a `AbortSignal` trait.
To ensure that the old behavior can be reproduced, I added a `CtrlCAbortSignal` struct that implements the `AbortSignal` trait.